### PR TITLE
Fix for JInstaller: :Install: Can't find Joomla XML setup file.

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -100,7 +100,7 @@
 		</copy>
 
 		<!-- Create the package -->
-		<zipme basedir="${dirs.strapper}" prefix="strapper/" destfile="${dirs.release}/file_strapper30-${version}.zip" includeemptydirs="true">
+		<zipme basedir="${dirs.strapper}" destfile="${dirs.release}/file_strapper30-${version}.zip" includeemptydirs="true">
 			<fileset dir="${dirs.strapper}" id="strapper">
 				<include name="**" />
 			</fileset>


### PR DESCRIPTION
The *prefix="strapper/"* buries the strapper package in an unnecessary folder resulting in a *JInstaller: :Install: Can't find Joomla XML setup file.* error.

Related to akeebasubs issue [#149](https://github.com/akeeba/akeebasubs/issues/149)